### PR TITLE
Fix search param sync bug

### DIFF
--- a/src/components/ProductGrid.tsx
+++ b/src/components/ProductGrid.tsx
@@ -16,9 +16,7 @@ const ProductGrid = () => {
 
   useEffect(() => {
     const urlSearch = searchParams.get('search');
-    if (urlSearch) {
-      setSearchQuery(urlSearch);
-    }
+    setSearchQuery(urlSearch ?? '');
   }, [searchParams]);
 
   const handleSearch = (query: string) => {


### PR DESCRIPTION
## Summary
- keep ProductGrid search box in sync with URL

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851298b756083249dd4227b52382294